### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through hands-on GitHub projects as part of the school's GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing "GitHub Skills" extracurricular activity to resolve issue #6.

## Changes
- Added `GitHub Skills` entry to the activities dictionary in `src/app.py`
- Activity includes description referencing the GitHub Certifications program, a Wednesday schedule, 25 max participants, and an empty participants list ready for sign-ups

## Closes
Closes #6